### PR TITLE
Update internal repo links

### DIFF
--- a/content/posts/links/2011-05-04-less-dot-app.md
+++ b/content/posts/links/2011-05-04-less-dot-app.md
@@ -15,7 +15,7 @@ tags:
   - LESS
   - Utilities
 
-ghi: "https://github.com/spatula/phillipridlen/issues/9"
+ghi: "https://github.com/philtr/phillipridlen/issues/9"
 ---
 
 [Less.app](<%= @item[:link][:source] %>):

--- a/content/posts/links/2014-12-13-o-come-let-us-adore-him.md
+++ b/content/posts/links/2014-12-13-o-come-let-us-adore-him.md
@@ -13,7 +13,7 @@ tags:
   - Hymns
   - Carols
 
-ghi: "https://github.com/spatula/phillipridlen/issues/14"
+ghi: "https://github.com/philtr/phillipridlen/issues/14"
 ---
 
 [John Piper](<%= @item[:link][:source] %>):

--- a/content/posts/links/2014-12-16-the-curse-of-compressing-reality.md
+++ b/content/posts/links/2014-12-16-the-curse-of-compressing-reality.md
@@ -17,7 +17,7 @@ tags:
 link:
   source: http://signalvnoise.com/posts/3813-the-curse-of-compressing-reality
 
-ghi: "https://github.com/spatula/phillipridlen/issues/16"
+ghi: "https://github.com/philtr/phillipridlen/issues/16"
 ---
 
 Noah Lorang on [Signal v. Noise](https://signalvnoise.com/posts/3813-the-curse-of-compressing-reality):

--- a/content/posts/links/2014-12-17-google-web-fonts-typographic-project.md
+++ b/content/posts/links/2014-12-17-google-web-fonts-typographic-project.md
@@ -15,7 +15,7 @@ link:
   via: Decodering
   via_link: "http://decodering.com/post/96269660184/google-font-pairings"
 
-ghi: "https://github.com/spatula/phillipridlen/issues/19"
+ghi: "https://github.com/philtr/phillipridlen/issues/19"
 ---
 
 > There are over 650 [Google Fonts](https://www.google.com/fonts) available for free. But, pairing

--- a/content/posts/notes/2010-08-05-shapeshifting-classes.md
+++ b/content/posts/notes/2010-08-05-shapeshifting-classes.md
@@ -10,7 +10,7 @@ tags:
   - Object-Oriented Programming
   - Constants
 
-ghi: "https://github.com/spatula/phillipridlen/issues/5"
+ghi: "https://github.com/philtr/phillipridlen/issues/5"
 
 styles:
   - code

--- a/content/posts/notes/2010-08-12-using-the-heroku-gem-inside-your-app.md
+++ b/content/posts/notes/2010-08-12-using-the-heroku-gem-inside-your-app.md
@@ -12,7 +12,7 @@ tags:
   - Gems
   - API
 
-ghi: "https://github.com/spatula/phillipridlen/issues/6"
+ghi: "https://github.com/philtr/phillipridlen/issues/6"
 
 styles:
   - code

--- a/content/posts/notes/2011-02-17-head-in-the-clouds.md
+++ b/content/posts/notes/2011-02-17-head-in-the-clouds.md
@@ -11,7 +11,7 @@ tags:
   - Backups
   - Hosting
 
-ghi: "https://github.com/spatula/phillipridlen/issues/8"
+ghi: "https://github.com/philtr/phillipridlen/issues/8"
 ---
 Valentine's day was a few days ago, and since I'm still in the mood, I am going
 to declare my love for the cloud. I love that at [Balcom

--- a/content/posts/notes/2011-05-03-moms-secret-sauce-for-success.md
+++ b/content/posts/notes/2011-05-03-moms-secret-sauce-for-success.md
@@ -9,7 +9,7 @@ tags:
   - Mother's Day
   - Learning
 
-ghi: "https://github.com/spatula/phillipridlen/issues/12"
+ghi: "https://github.com/philtr/phillipridlen/issues/12"
 
 styles:
   - posts/journal

--- a/content/posts/notes/2011-11-11-thank-you-dvorak.md
+++ b/content/posts/notes/2011-11-11-thank-you-dvorak.md
@@ -11,7 +11,7 @@ tags:
   - Keyboard
   - Dvorak
 
-ghi: "https://github.com/spatula/phillipridlen/issues/10"
+ghi: "https://github.com/philtr/phillipridlen/issues/10"
 
 styles:
   - posts/journal

--- a/content/posts/notes/2012-12-13-returning-multiple-formats-with-custom-dynamic-error-pages-in-rails.md
+++ b/content/posts/notes/2012-12-13-returning-multiple-formats-with-custom-dynamic-error-pages-in-rails.md
@@ -16,7 +16,7 @@ tags:
   - JSON
   - Errors
 
-ghi: "https://github.com/spatula/phillipridlen/issues/7"
+ghi: "https://github.com/philtr/phillipridlen/issues/7"
 
 styles:
   - code

--- a/content/posts/notes/2014-12-06-jekyll-s3-cloudfront.md
+++ b/content/posts/notes/2014-12-06-jekyll-s3-cloudfront.md
@@ -13,7 +13,7 @@ tags:
   - Hosting
   - Deployment
 
-ghi: "https://github.com/spatula/phillipridlen/issues/11"
+ghi: "https://github.com/philtr/phillipridlen/issues/11"
 ---
 
 GitHub pages is awesome. Like, _really_ awesome. But I wanted to try something new that would give

--- a/content/posts/notes/2014-12-10-being-careful-about-what-we-ingest.md
+++ b/content/posts/notes/2014-12-10-being-careful-about-what-we-ingest.md
@@ -13,7 +13,7 @@ tags:
   - Growth
   - Pleasing God
 
-ghi: "https://github.com/spatula/phillipridlen/issues/13"
+ghi: "https://github.com/philtr/phillipridlen/issues/13"
 
 styles:
   - posts/journal


### PR DESCRIPTION
## Summary
- fix old GitHub repo URLs in post front matter

## Testing
- `grep -r "github.com/philtr/phillipridlen" -n content/posts | wc -l`

------
https://chatgpt.com/codex/tasks/task_e_684a41ed5a548328834d43f107a3fd4f