### PR TITLE
Fix typo in rules.rb comment

### DIFF
--- a/rules.rb
+++ b/rules.rb
@@ -1,6 +1,6 @@
 # Rules
 #
-# Try to keep the number of rules defined in this file to a minumum.
+# Try to keep the number of rules defined in this file to a minimum.
 #
 # - Preprocess methods can go in `lib/preprocessors`
 # - Rule sets go in `lib/rules` and have their own preprocess blocks


### PR DESCRIPTION
## Summary
- fix typo in comment at top of `rules.rb`

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_684a41db9a9c8328a6e9f76075367a25