### PR TITLE
Fix README Ruby version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,20 @@
+# Phillip Ridlen's Website
+
+This repository contains the source for <https://phillipridlen.com>.
+It is built with [Nanoc](https://nanoc.app) and a handful of custom
+helpers.
+
+## Running Locally
+
+1. Install Ruby 3.4.1 and Bundler.
+2. Run `bundle install` to fetch the gems.
+3. Use `bundle exec nanoc live` to start a local server or
+   `bundle exec nanoc compile` to generate the static files.
+
+## Content and Code
+
+All posts, photographs, and other written content are copyright Phillip
+Ridlen. Please do not republish this material without permission.
+
+The code in this repository may be reused however you like. Fork it, copy
+it, or adapt it for your own projects.


### PR DESCRIPTION
## Summary
- clarify required Ruby version in README

## Testing
- `bundle install`
- `bundle exec nanoc compile`

------
https://chatgpt.com/codex/tasks/task_e_684a40ff44108328a2be93ef6fcad01c