### PR TITLE
Add RSpec coverage for lib

### DIFF
--- a/spec/lib/filters/binary_text_content_spec.rb
+++ b/spec/lib/filters/binary_text_content_spec.rb
@@ -1,0 +1,9 @@
+require 'filters/binary_text_content'
+
+RSpec.describe BinaryTextContent do
+  it 'returns the provided content parameter' do
+    filter = described_class.new
+    result = filter.setup_and_run('ignored', content: 'hello')
+    expect(result).to eq('hello')
+  end
+end

--- a/spec/lib/filters/haml_spec.rb
+++ b/spec/lib/filters/haml_spec.rb
@@ -1,0 +1,9 @@
+require 'filters/haml'
+
+RSpec.describe NanocFilters::Haml do
+  it 'renders Haml templates' do
+    filter = described_class.new(name: 'World')
+    result = filter.setup_and_run('%p= "Hello #{name}"')
+    expect(result.strip).to eq('<p>Hello World</p>')
+  end
+end

--- a/spec/lib/filters/image_spec.rb
+++ b/spec/lib/filters/image_spec.rb
@@ -1,0 +1,41 @@
+require 'filters/image'
+
+RSpec.describe Image::ResizeToFill do
+  let(:image_double) { double('Magick::ImageList') }
+
+  before do
+    allow(Magick::ImageList).to receive(:new).and_return(image_double)
+    allow(image_double).to receive(:resize_to_fill!)
+    allow(image_double).to receive(:write) do |path|
+      FileUtils.touch(path)
+    end
+  end
+
+  it 'resizes and writes the image' do
+    filter = described_class.new
+    filter.setup_and_run('image.jpg', width: 1, height: 2, gravity: :center)
+    expect(Magick::ImageList).to have_received(:new).with('image.jpg')
+    expect(image_double).to have_received(:resize_to_fill!).with(1, 2, :center)
+    expect(image_double).to have_received(:write).with(filter.output_filename)
+  end
+end
+
+RSpec.describe Image::ResizeToFit do
+  let(:image_double) { double('Magick::ImageList') }
+
+  before do
+    allow(Magick::ImageList).to receive(:new).and_return(image_double)
+    allow(image_double).to receive(:resize_to_fit!)
+    allow(image_double).to receive(:write) do |path|
+      FileUtils.touch(path)
+    end
+  end
+
+  it 'resizes and writes the image' do
+    filter = described_class.new
+    filter.setup_and_run('image.jpg', width: 1, height: 2)
+    expect(Magick::ImageList).to have_received(:new).with('image.jpg')
+    expect(image_double).to have_received(:resize_to_fit!).with(1, 2)
+    expect(image_double).to have_received(:write).with(filter.output_filename)
+  end
+end

--- a/spec/lib/helpers_spec.rb
+++ b/spec/lib/helpers_spec.rb
@@ -1,0 +1,30 @@
+# Stub `use_helper` used by `helpers.rb`
+def use_helper(*)
+  # no-op for testing
+end
+
+require 'helpers'
+
+RSpec.describe 'helpers' do
+  before do
+    @items = []
+    @item = double(attributes: {}, reps: {})
+  end
+
+  describe '#body_classes' do
+    it 'combines body class arrays' do
+      @body_classes = ['a']
+      @item = { body_classes: ['b'] }
+      expect(body_classes).to eq(%w[a b])
+    end
+  end
+
+  describe '#posts_sorted_by_date' do
+    it 'sorts posts by date descending' do
+      now = Time.now
+      a = { date: now - 1 }
+      b = { date: now }
+      expect(posts_sorted_by_date([a,b])).to eq([b,a])
+    end
+  end
+end

--- a/spec/lib/phillip_ridlen/data_sources/exif/item_spec.rb
+++ b/spec/lib/phillip_ridlen/data_sources/exif/item_spec.rb
@@ -1,0 +1,39 @@
+require 'phillip_ridlen/data_sources/exif'
+require 'phillip_ridlen/data_sources/exif/item'
+
+RSpec.describe PhillipRidlen::DataSources::Exif::Item do
+  let(:exif_hash) do
+    {
+      image_description: 'Sunset',
+      user_comment: 'Nice photo',
+      date_time_original: '2024:01:02 03:04:05',
+      source_file: '/tmp/photo.jpg',
+      make: 'Canon',
+      model: 'EOS',
+      lens_info: 'f/1.8',
+      f_number: '1.8',
+      exposure_time: '1/250',
+      iso: 200
+    }
+  end
+
+  before do
+    exiftool = instance_double('Exiftool', to_hash: exif_hash)
+    allow(Exiftool).to receive(:new).and_return(exiftool)
+  end
+
+  subject { described_class.new('/tmp/photo.jpg') }
+
+  it 'parses attributes from exif data' do
+    attrs = subject.attributes
+    expect(attrs[:title]).to eq('Sunset')
+    expect(attrs[:description]).to eq('Nice photo')
+    expect(attrs[:date]).to eq(Time.new(2024,1,2,3,4,5))
+    expect(attrs[:filename]).to eq('/tmp/photo.jpg')
+    expect(attrs[:camera]).to eq('Canon EOS')
+    expect(attrs[:lens]).to eq("𝑓/1.8")
+    expect(attrs[:f_stop]).to eq("𝑓/1.8")
+    expect(attrs[:exposure]).to eq('1/250𝑠')
+    expect(attrs[:iso]).to eq(200)
+  end
+end

--- a/spec/lib/phillip_ridlen/data_sources/exif_spec.rb
+++ b/spec/lib/phillip_ridlen/data_sources/exif_spec.rb
@@ -1,0 +1,15 @@
+require 'phillip_ridlen/data_sources/exif'
+
+RSpec.describe PhillipRidlen::DataSources::Exif do
+  subject do
+    described_class.new({}, '/', '/', content_dir: 'photos', ext: %w[jpg png])
+  end
+
+  it 'builds a file glob from config' do
+    expect(subject.file_glob).to end_with('/**/*.{jpg,png}')
+  end
+
+  it 'returns extension array' do
+    expect(subject.ext).to eq(%w[jpg png])
+  end
+end

--- a/spec/lib/phillip_ridlen/data_sources/filesystem_listener_spec.rb
+++ b/spec/lib/phillip_ridlen/data_sources/filesystem_listener_spec.rb
@@ -1,0 +1,15 @@
+require 'phillip_ridlen/data_sources/filesystem_listener'
+
+class DummyListener
+  include PhillipRidlen::DataSources::FilesystemListener
+  def initialize(config) = @config = config
+end
+
+RSpec.describe PhillipRidlen::DataSources::FilesystemListener do
+  subject { DummyListener.new(content_dir: 'c', layouts_dir: 'l') }
+
+  it 'returns directories from config' do
+    expect(subject.send(:dir_for, :content)).to eq('c')
+    expect(subject.send(:dir_for, :layouts)).to eq('l')
+  end
+end

--- a/spec/lib/phillip_ridlen/data_sources/nanoc_transformable_spec.rb
+++ b/spec/lib/phillip_ridlen/data_sources/nanoc_transformable_spec.rb
@@ -1,0 +1,43 @@
+require 'phillip_ridlen/data_sources/nanoc_transformable'
+
+class DummyBinary
+  include PhillipRidlen::DataSources::NanocTransformable::Binary
+
+  attr_reader :attributes
+  def initialize(attrs) = @attributes = attrs
+end
+
+class DummyTextual
+  include PhillipRidlen::DataSources::NanocTransformable::Textual
+
+  attr_reader :attributes
+  def initialize(attrs) = @attributes = attrs
+end
+
+class DummyNoMode
+  include PhillipRidlen::DataSources::NanocTransformable
+
+  attr_reader :attributes
+  def initialize(attrs) = @attributes = attrs
+end
+
+RSpec.describe PhillipRidlen::DataSources::NanocTransformable do
+  let(:ds) { double('data_source') }
+
+  it 'builds binary nanoc items' do
+    dummy = DummyBinary.new(filename: '/foo.jpg')
+    expect(ds).to receive(:new_item).with('/foo.jpg', dummy.attributes, instance_of(Nanoc::Core::Identifier), binary: true)
+    dummy.to_nanoc_item(ds)
+  end
+
+  it 'builds textual nanoc items' do
+    dummy = DummyTextual.new(filename: '/id', content: 'text')
+    expect(ds).to receive(:new_item).with('text', dummy.attributes, instance_of(Nanoc::Core::Identifier), binary: false)
+    dummy.to_nanoc_item(ds)
+  end
+
+  it 'raises when no mode included' do
+    dummy = DummyNoMode.new(filename: 'id')
+    expect { dummy.filename_or_content }.to raise_error(RuntimeError)
+  end
+end

--- a/spec/lib/preprocessors/blog_spec.rb
+++ b/spec/lib/preprocessors/blog_spec.rb
@@ -1,0 +1,53 @@
+require 'active_support/core_ext/string'
+require 'preprocessors/blog'
+
+class ItemCollection
+  def initialize
+    @items = []
+  end
+
+  def <<(item)
+    @items << item
+  end
+
+  def find_all(pattern)
+    if pattern.is_a?(Regexp)
+      @items.select { |i| i.identifier =~ pattern }
+    else
+      @items.select { |i| File.fnmatch(pattern, i.identifier, File::FNM_PATHNAME) }
+    end
+  end
+end
+
+RSpec.describe 'blog preprocessors' do
+  let(:items) { ItemCollection.new }
+  let(:config) { { drafts: false } }
+
+  before do
+    @items = items
+    @config = config
+  end
+
+  describe '#blog_post_attributes_from_filename' do
+    it 'sets attributes based on filename' do
+      item = double(identifier: '/posts/notes/2024-01-02-test.md', :[]= => nil)
+      allow(item).to receive(:[]=)
+      items << item
+      blog_post_attributes_from_filename
+      expect(item).to have_received(:[]=).with(:post_type, 'note')
+      expect(item).to have_received(:[]=).with(:date, Time.new('2024','01','02'))
+      expect(item).to have_received(:[]=).with(:slug, 'test')
+    end
+  end
+
+  describe '#blog_post_date_for_drafts' do
+    it 'assigns date to draft items when drafts enabled' do
+      config[:drafts] = true
+      draft = double(:draft, identifier: '/drafts/foo.md')
+      allow(draft).to receive(:[]=)
+      items << draft
+      blog_post_date_for_drafts
+      expect(draft).to have_received(:[]=).with(:date, kind_of(Time))
+    end
+  end
+end

--- a/spec/lib/preprocessors/layout_spec.rb
+++ b/spec/lib/preprocessors/layout_spec.rb
@@ -1,0 +1,12 @@
+require 'preprocessors/layout'
+
+RSpec.describe '#selected_layout' do
+  it 'returns layout glob when layout attribute exists' do
+    item = { layout: 'base' }
+    expect(selected_layout(item)).to eq('/base.*')
+  end
+
+  it 'returns nil when layout attribute missing' do
+    expect(selected_layout({})).to be_nil
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -13,6 +13,10 @@
 # it.
 #
 # See https://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
+
+# Pull in Nanoc for filter and data source classes used by the library
+require 'nanoc'
+
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest


### PR DESCRIPTION
## Summary
- add missing RSpec configuration stubs
- create support stub for Nanoc Filesystem data source
- add specs for helper modules, filters, preprocessors and data sources
- require real Nanoc gem in specs

## Testing
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_684a6000f3608328828d2b501cf0e098