### PR TITLE
Add RDoc comments to FreshRSS classes

### DIFF
--- a/lib/freshrss/client.rb
+++ b/lib/freshrss/client.rb
@@ -1,14 +1,26 @@
-# Simple HTTP client for the FreshRSS API.
-# Supports fetching the list of starred items using Google Reader compatible endpoints.
-#
 require "json"
 require "net/http"
 require "uri"
 
 module FreshRSS
+  # Simple HTTP client for the FreshRSS API.
+  # Supports fetching the list of starred items using Google Reader compatible
+  # endpoints.
   class Client
+    # The configuration used by the client.
+    #
+    # @return [FreshRSS::Config]
     attr_reader :config
 
+    # Create a new API client.
+    #
+    # A `FreshRSS::Config` instance can be provided directly, or connection
+    # parameters may be given individually.
+    #
+    # @param config [FreshRSS::Config, nil] optional configuration object
+    # @param instance_url [String, nil] base URL of the FreshRSS instance
+    # @param username [String, nil] API username
+    # @param api_password [String, nil] API password
     def initialize(config = nil, instance_url: nil, username: nil, api_password: nil)
       @config = config || FreshRSS::Config.new
 
@@ -19,6 +31,10 @@ module FreshRSS
       yield @config if block_given?
     end
 
+    # Fetch starred entries for the configured account.
+    #
+    # @param limit [Integer] maximum number of entries to return
+    # @return [Hash] parsed JSON response from the API
     def starred(limit: 50)
       uri = URI("#{config.instance_url}/api/greader.php/reader/api/0/stream/contents/user/-/state/com.google/starred")
       params = {n: limit, output: "json"}

--- a/lib/freshrss/config.rb
+++ b/lib/freshrss/config.rb
@@ -1,11 +1,25 @@
-# Configuration container for the FreshRSS client.
-# Stores connection details such as instance URL and credentials.
-#
-module FreshRSS
-  class Config
-    attr_reader :instance_url, :username, :api_password
-    attr_writer :username, :api_password
+# frozen_string_literal: true
 
+module FreshRSS
+  # Configuration container for the FreshRSS client.
+  # Stores connection details such as instance URL and credentials.
+  class Config
+    # URL of the FreshRSS instance.
+    attr_reader :instance_url
+    # Username used for API requests.
+    attr_reader :username
+    # API password for the user.
+    attr_reader :api_password
+
+    # Set the username.
+    attr_writer :username
+    # Set the API password.
+    attr_writer :api_password
+
+    # Initialize a new configuration object.
+    #
+    # @param attrs [Hash] optional attributes
+    # @yieldparam config [Config] yields itself for configuration
     def initialize(attrs = {})
       self.instance_url = attrs[:instance_url] || attrs["instance_url"]
       self.username = attrs[:username] || attrs["username"]
@@ -14,6 +28,10 @@ module FreshRSS
       yield self if block_given?
     end
 
+    # Set the URL of the FreshRSS instance.
+    # Trailing slashes are removed.
+    #
+    # @param instance_url [String]
     def instance_url=(instance_url)
       @instance_url = instance_url&.chomp("/")
     end


### PR DESCRIPTION
## Summary
- move class documentation directly above class definitions
- add RDoc comments for public methods in `FreshRSS::Client` and `FreshRSS::Config`

## Testing
- `bundle exec standardrb`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_684c5c587b648328baaa6f53581d426b