### PR TITLE
Add YouTube playlist data source

### DIFF
--- a/lib/data_sources/youtube.rb
+++ b/lib/data_sources/youtube.rb
@@ -1,0 +1,82 @@
+require "base64"
+require "nanoc/data_sources/filesystem"
+require "yaml"
+require "cgi"
+
+require_relative "../youtube/client"
+
+module DataSources
+  # Data source that fetches videos from YouTube playlists and caches them
+  class Youtube < Nanoc::DataSources::Filesystem
+    identifier :youtube
+
+    def items
+      fetch_and_cache
+      super
+    end
+
+    def content_dir_name
+      config.fetch(:content_dir, "src/links/youtube")
+    end
+
+    private
+
+    def fetch_and_cache
+      playlists.each do |url|
+        playlist_id = extract_playlist_id(url)
+        next unless playlist_id
+        data = client.playlist_items(playlist_id, limit: limit)
+        Array(data["items"]).each { |item| cache_item(item) }
+      end
+    rescue => e
+      warn "YouTube data source error: #{e.message}"
+    end
+
+    def playlists
+      Array(config[:playlists])
+    end
+
+    def extract_playlist_id(url)
+      uri = URI.parse(url)
+      CGI.parse(uri.query.to_s)["list"]&.first || uri.path.split("/").last || url
+    rescue URI::InvalidURIError
+      url
+    end
+
+    def client
+      @client ||= ::Youtube::Client.new do |c|
+        c.api_key = ENV.fetch("YOUTUBE_API_KEY") { config[:api_key] }
+      end
+    end
+
+    def limit
+      config.fetch(:limit, 50)
+    end
+
+    def cache_item(item)
+      id = sanitize_id(item["id"])
+      path = File.join(content_dir_name, "#{id}.md")
+      return if File.exist?(path)
+
+      FileUtils.mkdir_p(File.dirname(path))
+      File.write(path, build_document(item))
+    end
+
+    def sanitize_id(id)
+      Base64.urlsafe_encode64(id.to_s, padding: false)
+    end
+
+    def build_document(item)
+      snippet = item["snippet"] || {}
+      attrs = {
+        "title" => snippet["title"],
+        "url" => "https://www.youtube.com/watch?v=#{snippet.dig("resourceId", "videoId")}",
+        "published" => (snippet["publishedAt"] || Time.now).to_s,
+        "source" => "YouTube"
+      }
+      frontmatter = attrs.to_yaml.chomp
+      content = snippet["description"]
+      [frontmatter, content].join("\n---\n")
+    end
+  end
+end

--- a/lib/youtube/client.rb
+++ b/lib/youtube/client.rb
@@ -1,0 +1,36 @@
+require "json"
+require "net/http"
+require "uri"
+
+require_relative "config"
+
+module Youtube
+  # Simple HTTP client for the YouTube Data API
+  class Client
+    attr_reader :config
+
+    def initialize(config = nil, api_key: nil)
+      @config = config || Youtube::Config.new
+      @config.api_key = api_key if api_key && !api_key.empty?
+      yield @config if block_given?
+    end
+
+    def playlist_items(playlist_id, limit: 50)
+      uri = URI("https://www.googleapis.com/youtube/v3/playlistItems")
+      params = {
+        part: "snippet",
+        playlistId: playlist_id,
+        maxResults: limit,
+        key: config.api_key
+      }
+      uri.query = URI.encode_www_form(params)
+
+      req = Net::HTTP::Get.new(uri)
+
+      Net::HTTP.start(uri.host, uri.port, use_ssl: true) do |http|
+        res = http.request(req)
+        JSON.parse(res.body)
+      end
+    end
+  end
+end

--- a/lib/youtube/config.rb
+++ b/lib/youtube/config.rb
@@ -1,0 +1,11 @@
+module Youtube
+  # Configuration for Youtube client
+  class Config
+    attr_accessor :api_key
+
+    def initialize(attrs = {})
+      @api_key = attrs[:api_key] || attrs["api_key"]
+      yield self if block_given?
+    end
+  end
+end

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -82,3 +82,10 @@ data_sources:
     content_dir: src/links/freshrss
     items_root: /links/freshrss/
     limit: 50
+
+  - name: "YouTube"
+    type: youtube
+    content_dir: src/links/youtube
+    items_root: /links/youtube
+    playlists:
+      - https://www.youtube.com/playlist?list=PLBLy6gcs2twdhXFnQtV7NAP6XhMhQ8ZSJ

--- a/spec/lib/data_sources/youtube_spec.rb
+++ b/spec/lib/data_sources/youtube_spec.rb
@@ -1,0 +1,67 @@
+require "data_sources/youtube"
+require "tmpdir"
+require "yaml"
+
+RSpec.describe DataSources::Youtube do
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:config) do
+    {
+      api_key: "k",
+      playlists: ["https://www.youtube.com/playlist?list=PL1"],
+      content_dir: tmpdir,
+      limit: 50
+    }
+  end
+  subject { described_class.new({text_extensions: ["md"]}, "/", "/", config) }
+
+  let(:response) do
+    {
+      "items" => [
+        {
+          "id" => "abc",
+          "snippet" => {
+            "title" => "Video",
+            "description" => "Body",
+            "publishedAt" => "2024-01-01T00:00:00Z",
+            "resourceId" => {"videoId" => "v123"}
+          }
+        }
+      ]
+    }
+  end
+
+  before do
+    client = instance_double(Youtube::Client)
+    allow(Youtube::Client).to receive(:new).and_return(client)
+    allow(client).to receive(:playlist_items).with("PL1", limit: 50).and_return(response)
+  end
+
+  after do
+    FileUtils.remove_entry(tmpdir)
+  end
+
+  it "writes new items to markdown" do
+    subject.items
+    encoded_id = Base64.urlsafe_encode64("abc", padding: false)
+    file = File.join(tmpdir, "#{encoded_id}.md")
+    expect(File).to exist(file)
+    yaml = File.read(file)[/\A---\n(.*?)\n---/m, 1]
+    data = YAML.safe_load(yaml)
+    expect(data["title"]).to eq("Video")
+    expect(data["url"]).to eq("https://www.youtube.com/watch?v=v123")
+    expect(data["source"]).to eq("YouTube")
+  end
+
+  it "sanitizes ids (urlsafe base64)" do
+    expect(subject.send(:sanitize_id, "a/b?c")).to eq("YS9iP2M")
+  end
+
+  it "skips when file exists" do
+    encoded_id = Base64.urlsafe_encode64("abc", padding: false)
+    file = File.join(tmpdir, "#{encoded_id}.md")
+    FileUtils.mkdir_p(tmpdir)
+    File.write(file, "old")
+    subject.items
+    expect(File.read(file)).to eq("old")
+  end
+end

--- a/spec/lib/youtube/client_spec.rb
+++ b/spec/lib/youtube/client_spec.rb
@@ -1,0 +1,31 @@
+require "youtube/client"
+
+RSpec.describe Youtube::Client do
+  subject { described_class.new(api_key: "key") }
+
+  it "requests playlist items" do
+    uri = URI("https://www.googleapis.com/youtube/v3/playlistItems")
+    params = {part: "snippet", playlistId: "PL1", maxResults: 10, key: "key"}
+    uri.query = URI.encode_www_form(params)
+
+    request = instance_double(Net::HTTP::Get)
+    expect(Net::HTTP::Get).to receive(:new).with(uri).and_return(request)
+
+    http = double
+    response = double(body: '{"items":[]}')
+    expect(Net::HTTP).to receive(:start).with(uri.host, uri.port, use_ssl: true).and_yield(http)
+    expect(http).to receive(:request).with(request).and_return(response)
+
+    result = subject.playlist_items("PL1", limit: 10)
+    expect(result).to eq("items" => [])
+  end
+
+  it "can receive a config object or parameters" do
+    config = Youtube::Config.new(api_key: "k")
+    expect(described_class.new(config)).to be_a(Youtube::Client)
+
+    both = described_class.new(config, api_key: "x")
+    new_config = both.instance_variable_get(:@config)
+    expect(new_config.api_key).to eq("x")
+  end
+end


### PR DESCRIPTION
## Summary
- pull YouTube playlists using a new data source and client
- configure Nanoc with a YouTube link source
- test YouTube client and data source

## Testing
- `bundle exec standardrb`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_684ca5ffe7d883288146c5f8a6d1464e