### PR TITLE
Add immutable games versioning support

### DIFF
--- a/bin/hooks/pre-commit
+++ b/bin/hooks/pre-commit
@@ -1,0 +1,14 @@
+#!/usr/bin/env ruby
+changes = `git diff --cached --name-status`.split("\n")
+errors = []
+changes.each do |line|
+  status, path = line.split(/\s+/, 2)
+  next unless path&.start_with?("src/games/")
+  next if status == "A"
+  errors << path
+end
+
+unless errors.empty?
+  warn "Modifying existing game files is not allowed:\n  #{errors.join("\n  ")}"
+  exit 1
+end

--- a/bin/setup
+++ b/bin/setup
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+set -euo pipefail
+bundle install
+HOOKS_DIR="$(git rev-parse --git-dir)/hooks"
+mkdir -p "$HOOKS_DIR"
+ln -sf "$(pwd)/bin/hooks/pre-commit" "$HOOKS_DIR/pre-commit"
+echo "Git hooks installed"

--- a/config/rules/games.rb
+++ b/config/rules/games.rb
@@ -1,0 +1,25 @@
+# Compilation rules for game pages with immutable versions.
+# Creates latest index page for each game and versioned permalinks.
+
+preprocess do
+  game_attributes_from_filename
+  game_latest_items
+end
+
+compile "/games/**/*.md" do
+  filter :erb
+  filter :kramdown
+  filter :colorize_syntax, default_colorizer: :rouge
+
+  layout selected_layout(@item) || "/default.*"
+  filter :typogruby
+
+  slug = @item[:slug]
+  version = @item[:version]
+
+  if @item.identifier.end_with?("index.md")
+    write "/games/#{slug}/index.html"
+  else
+    write "/games/#{slug}/#{version}/index.html"
+  end
+end

--- a/lib/preprocessors/games.rb
+++ b/lib/preprocessors/games.rb
@@ -1,0 +1,28 @@
+# Preprocessor helpers for game versioning.
+# Extracts version information from filenames and creates an index
+# item for the latest version of each game.
+GAME_REGEX = %r{\A/games/([^/]+)/(\d{12})\.md\z}
+
+# Returns collection of game version items
+def game_items
+  @items.find_all(GAME_REGEX)
+end
+
+# Sets slug and version attributes on game items
+def game_attributes_from_filename
+  game_items.each do |item|
+    slug, version = item.identifier.to_s.match(GAME_REGEX).captures
+    item[:slug] = slug
+    item[:version] = version
+  end
+end
+
+# Marks latest version for each game and creates index item
+# pointing at the latest version's content.
+def game_latest_items
+  game_items.group_by { |i| i[:slug] }.each do |_slug, versions|
+    latest = versions.max_by { |i| i[:version] }
+    latest[:latest] = true
+    @items.create(latest.raw_content, latest.attributes, "/games/#{latest[:slug]}/index.md")
+  end
+end

--- a/nanoc.yaml
+++ b/nanoc.yaml
@@ -67,6 +67,11 @@ data_sources:
     content_dir: src/drafts
     items_root: /drafts/
 
+  - name: "Games"
+    type: filesystem
+    content_dir: src/games
+    items_root: /games/
+
   - name: "Stylesheets"
     type: filesystem
     content_dir: src/css

--- a/spec/lib/preprocessors/games_spec.rb
+++ b/spec/lib/preprocessors/games_spec.rb
@@ -1,0 +1,76 @@
+require "preprocessors/games"
+
+class ItemCollection
+  def initialize
+    @items = []
+  end
+
+  def <<(item)
+    @items << item
+  end
+
+  def find_all(pattern)
+    if pattern.is_a?(Regexp)
+      @items.select { |i| i.identifier =~ pattern }
+    else
+      @items.select { |i| File.fnmatch(pattern, i.identifier, File::FNM_PATHNAME) }
+    end
+  end
+
+  def create(content, attributes, identifier)
+    item = ItemDouble.new(identifier, content, attributes)
+    @items << item
+    item
+  end
+end
+
+class ItemDouble
+  attr_reader :identifier, :raw_content, :attributes
+
+  def initialize(identifier, raw_content = "", attributes = {})
+    @identifier = identifier
+    @raw_content = raw_content
+    @attributes = attributes
+  end
+
+  def []=(key, value)
+    @attributes[key] = value
+  end
+
+  def [](key)
+    @attributes[key]
+  end
+end
+
+RSpec.describe "games preprocessors" do
+  let(:items) { ItemCollection.new }
+
+  before do
+    @items = items
+  end
+
+  describe "#game_attributes_from_filename" do
+    it "sets slug and version" do
+      item = ItemDouble.new("/games/dodgeball/202507011516.md")
+      items << item
+      game_attributes_from_filename
+      expect(item[:slug]).to eq("dodgeball")
+      expect(item[:version]).to eq("202507011516")
+    end
+  end
+
+  describe "#game_latest_items" do
+    it "creates an index item for the latest version" do
+      older = ItemDouble.new("/games/dodgeball/202507011516.md", "old")
+      latest = ItemDouble.new("/games/dodgeball/202507051234.md", "new")
+      items << older
+      items << latest
+      game_attributes_from_filename
+      game_latest_items
+      index = items.find_all("/games/dodgeball/index.md").first
+      expect(index.raw_content).to eq("new")
+      expect(index.attributes[:slug]).to eq("dodgeball")
+      expect(index.attributes[:version]).to eq("202507051234")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- support immutable game versions via new preprocessor and rules
- add games data source
- ensure game files can't be modified with pre-commit hook
- setup script installs gems and hooks
- cover new behaviour with specs

## Testing
- `bundle exec standardrb`
- `bundle exec rspec`

------
https://chatgpt.com/codex/tasks/task_e_68695538856883289f672f64dfd10ace